### PR TITLE
changed textProcessor to keep a record of dropped docs.

### DIFF
--- a/R/textProcessor.R
+++ b/R/textProcessor.R
@@ -100,6 +100,10 @@ textProcessor <- function(documents, metadata=NULL,
     }
   }
   out <- read.slam(dtm) #using the read.slam() function in stm to convert
+  ## It's possible that the processing has caused some documents to be
+  ## dropped. These will be removed in the conversion from dtm to
+  ## internal representation.  Better keep a record
+  kept <- (1:length(documents) %in% unique(dtm$i))
   vocab <- as.character(out$vocab)
-  return(list(documents=out$documents, vocab=vocab, meta=metadata))
+  return(list(documents=out$documents, vocab=vocab, meta=metadata, docs.removed=which(!kept)))
 }


### PR DESCRIPTION
I noticed that for some collections of relatively short documents, the textProcessor function may silently drop some documents.  These have been documents containing only stop words after stemming, punctuation removal, etc. While the DocumentTerm matrix kept all the rows, when converted to the stm internal format inside textProcessor, these documents were silently dropped, so findThoughts on the original document collection raised an error because the number of documents didn't match.

This now returns a docs.removed element in the list, so I can remove them from the original set and proceed.  I'm using the results of textProcessor like this: like this:

    # processed contains the results of running textProcessor
    if (length(processed$docs.removed)) {
        documents <- documents[-processed$docs.removed,]
    }
