### PR TITLE
Preserves doc names, handles TDMs as well as DTMs

### DIFF
--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -43,7 +43,7 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
   # For right now we are just doing everything in serial.
   # the challenge with multicore is efficient scheduling while
   # maintaining a small dimension for the sufficient statistics.
-  print("Using the new code")
+  print("Using the new code 2")
   for(i in 1:N) {
     #update components
     doc <- documents[[i]]
@@ -65,11 +65,11 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
     betaexpeta_colsums <- 0
     betaexpeta <- 0
     sumexpeta <- 0
-    global_eta <- 0
+#    global_eta <- 0
     eta <- optim(par=init, 
                        fn=function(eta) {
                          # {\sum_{v=1}^V c_v log [\sum_k beta_{k,v} exp(eta_k)] }- Wlog \sum exp(eta_k)
-                         global_eta <<- eta
+#                         global_eta <<- eta
                          expeta <<- c(exp(eta),1)
                          sumexpeta <<- sum(expeta)
                          betaexpeta <<- beta.i * expeta
@@ -83,19 +83,19 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
                          part2 <- .5*sum(diff*siginvdiff)
                          part2 - part1  
                        },  gr=function(eta) {
-                         if (identical(eta,global_eta)) {
+#                         if (identical(eta,global_eta)) {
                            denom <- doc.ct/betaexpeta_colsums
                            part1 <- (betaexpeta%*%denom)[-length(expeta)] - expeta[1]*(Ndoc/sumexpeta)  
                            as.numeric(siginvdiff - part1)
-                         } else {
-                           expeta.sh <- exp(eta) 
-                           expeta <- c(expeta.sh,1)
-                           Ez <- expeta*beta
-                           denom <- doc.ct/.colSums(Ez, nrow(Ez), ncol(Ez))
-                           part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
-                           part2 <- siginv%*%(eta-mu) 
-                           as.numeric(part2 - part1)                           
-                         }
+#                          } else {
+#                            expeta.sh <- exp(eta) 
+#                            expeta <- c(expeta.sh,1)
+#                            Ez <- expeta*beta
+#                            denom <- doc.ct/.colSums(Ez, nrow(Ez), ncol(Ez))
+#                            part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
+#                            part2 <- siginv%*%(eta-mu) 
+#                            as.numeric(part2 - part1)                           
+#                          }
                        },
                        method="BFGS", 
                        control=list(maxit=500)

--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -43,7 +43,7 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
   # For right now we are just doing everything in serial.
   # the challenge with multicore is efficient scheduling while
   # maintaining a small dimension for the sufficient statistics.
-
+  print("Using the new code")
   for(i in 1:N) {
     #update components
     doc <- documents[[i]]

--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -43,6 +43,7 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
   # For right now we are just doing everything in serial.
   # the challenge with multicore is efficient scheduling while
   # maintaining a small dimension for the sufficient statistics.
+
   for(i in 1:N) {
     #update components
     doc <- documents[[i]]
@@ -60,55 +61,50 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
     Ndoc <- sum(doc.ct)
     cols = ncol(beta.i)
     rows = nrow(beta.i)
-    optim.out <- optim(par=init, 
+    siginvdiff <- 0
+    betaexpeta_colsums <- 0
+    betaexpeta <- 0
+    sumexpeta <- 0
+    eta <- optim(par=init, 
                        fn=function(eta) {
                          # {\sum_{v=1}^V c_v log [\sum_k beta_{k,v} exp(eta_k)] }- Wlog \sum exp(eta_k)
                          expeta <<- c(exp(eta),1)
-                         part1 <- sum(doc.ct*log(.colSums(beta.i*expeta, 
-                                                          rows, 
-                                                          cols
-                                                          )
-                                                 )
-                                      ) - Ndoc*log(sum(expeta))
+                         sumexpeta <<- sum(expeta)
+                         betaexpeta <<- beta.i * expeta
+                         betaexpeta_colsums <<- .colSums(betaexpeta, 
+                                                         rows, 
+                                                         cols)
+                         part1 <- sum(doc.ct*log(betaexpeta_colsums)) - Ndoc*log(sumexpeta)
                          # -1/2 (eta - mu)^T Sigma (eta - mu)
                          diff <<- eta-mu.i
-                         part2 <- .5*sum(diff*(siginv %*% diff))
+                         siginvdiff <<- siginv %*% diff
+                         part2 <- .5*sum(diff*siginvdiff)
                          part2 - part1  
                        },  gr=function(eta) {
-                         expeta.sh <- expeta[1] 
-                         Ez <- expeta*beta.i
-                         denom <- doc.ct/.colSums(Ez,  rows, cols)
-                         part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
-                         part2 <- siginv%*%(eta-mu.i) 
-                         as.numeric(part2 - part1)
+                         denom <- doc.ct/betaexpeta_colsums
+                         part1 <- (betaexpeta%*%denom)[-length(expeta)] - expeta[1]*(Ndoc/sumexpeta)  
+                         as.numeric(siginvdiff - part1)
                        },
                        method="BFGS", 
                        control=list(maxit=500)
-    )
+    )$par
     
     #Solve for Hessian/Phi/Bound returning the result
-    eta <- optim.out$par 
-#     doc.results <- hpb(optim.out$par, doc.ct=doc.ct, mu=mu.i,
-#         siginv=siginv, beta=beta.i, Ndoc=Ndoc,
-#         sigmaentropy=sigmaentropy)
-    
-#    expeta <- c(exp(eta),1)
-    theta <- expeta/sum(expeta)
-    
-    #pieces for the derivatives of the exp(eta)beta part
-    EB <- expeta*beta.i #calculate exp(eta)\beta for each word
-    EB <- t(EB)/colSums(EB) #transpose and norm by (now) the row
-    
-    #at this point EB is the phi matrix
-    phi <- EB*(doc.ct) #multiply through by word count
-    phisums <- colSums(phi)
-    phi <- t(phi) #transpose so its in the K by W format expected
-    EB <- EB*sqrt(doc.ct) #set up matrix to take the cross product
+      theta <- expeta/sumexpeta
+  
+   #pieces for the derivatives of the exp(eta)beta part
+       EB <- t(betaexpeta)/betaexpeta_colsums #transpose and norm by (now) the row
+  
+   #at this point EB is the phi matrix
+      phi <- EB*(doc.ct) #multiply through by word count
+      phisums <- colSums(phi)
+      phi <- t(phi) #transpose so its in the K by W format expected
+      EB <- EB*sqrt(doc.ct) #set up matrix to take the cross product
     
     #First piece is the quotient rule portion that shows up from E[z], second piece is the part
     # that shows up regardless as in Wang and Blei (2013) for example.  Last element is just siginv
-    hess <- -((diag(phisums) - crossprod(EB)) - 
-                Ndoc*(diag(theta) - theta%o%theta))[1:length(eta),1:length(eta)] + siginv
+     hess <- -((diag(phisums) - crossprod(EB)) - 
+                 Ndoc*(diag(theta) - theta%o%theta))[1:length(eta),1:length(eta)] + siginv
     
     ###
     # Bound
@@ -120,20 +116,20 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
       #only if we would produce negative variances do we bother doing nearPD
       if(any(diag(nu)<0)) nu <- as.matrix(nearPD(nu)$mat)
     }
-#    diff <- eta - mu.i
-    logphinorm <- log(colSums(theta*beta.i))
-    part1 <- sum(doc.ct*logphinorm)
-    bound <- part1 + .5*determinant(nu, logarithm=TRUE)$modulus -
-      .5*sum(diff*crossprod(diff,siginv)) - sigmaentropy
-    bound <- as.numeric(bound)
+     logphinorm <- log(colSums(theta*beta.i))
+     part1 <- sum(doc.ct*logphinorm)
+
+    bound[i] <- as.numeric(part1 + .5*determinant(nu, logarithm=TRUE)$modulus -
+      .5*sum(diff*crossprod(diff,siginv)) - sigmaentropy)
     
     # done inferring the document
-    
+
     # update sufficient statistics 
     sigma.ss <- sigma.ss + nu
     beta.ss[[aspect]][,words] <- phi + beta.ss[[aspect]][,words]
-    bound[i] <- bound
+
     lambda[[i]] <- eta
+
     if(verbose && i%%ctevery==0) cat(".")
   }
   if(verbose) cat("\n") #add a line break for the next message.

--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -52,15 +52,88 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
     if(update.mu) mu.i <- mu[,i]
     beta.i <- beta[[aspect]][,words,drop=FALSE]
     
-    #infer the document
-    doc.results <- logisticnormal(eta=init, mu=mu.i, siginv=siginv, beta=beta.i, 
-                                  doc=doc, sigmaentropy=sigmaentropy)
+    #infer the document - formerly the logisticnormal function
+    #even at K=100, BFGS is faster than L-BFGS
+    expeta <- 0
+    diff <- 0
+    doc.ct <- doc[2,]
+    Ndoc <- sum(doc.ct)
+    cols = ncol(beta.i)
+    rows = nrow(beta.i)
+    optim.out <- optim(par=init, 
+                       fn=function(eta) {
+                         # {\sum_{v=1}^V c_v log [\sum_k beta_{k,v} exp(eta_k)] }- Wlog \sum exp(eta_k)
+                         expeta <<- c(exp(eta),1)
+                         part1 <- sum(doc.ct*log(.colSums(beta.i*expeta, 
+                                                          rows, 
+                                                          cols
+                                                          )
+                                                 )
+                                      ) - Ndoc*log(sum(expeta))
+                         # -1/2 (eta - mu)^T Sigma (eta - mu)
+                         diff <<- eta-mu.i
+                         part2 <- .5*sum(diff*(siginv %*% diff))
+                         part2 - part1  
+                       },  gr=function(eta) {
+                         expeta.sh <- expeta[1] 
+                         Ez <- expeta*beta.i
+                         denom <- doc.ct/.colSums(Ez,  rows, cols)
+                         part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
+                         part2 <- siginv%*%(eta-mu.i) 
+                         as.numeric(part2 - part1)
+                       },
+                       method="BFGS", 
+                       control=list(maxit=500)
+    )
+    
+    #Solve for Hessian/Phi/Bound returning the result
+    eta <- optim.out$par 
+#     doc.results <- hpb(optim.out$par, doc.ct=doc.ct, mu=mu.i,
+#         siginv=siginv, beta=beta.i, Ndoc=Ndoc,
+#         sigmaentropy=sigmaentropy)
+    
+#    expeta <- c(exp(eta),1)
+    theta <- expeta/sum(expeta)
+    
+    #pieces for the derivatives of the exp(eta)beta part
+    EB <- expeta*beta.i #calculate exp(eta)\beta for each word
+    EB <- t(EB)/colSums(EB) #transpose and norm by (now) the row
+    
+    #at this point EB is the phi matrix
+    phi <- EB*(doc.ct) #multiply through by word count
+    phisums <- colSums(phi)
+    phi <- t(phi) #transpose so its in the K by W format expected
+    EB <- EB*sqrt(doc.ct) #set up matrix to take the cross product
+    
+    #First piece is the quotient rule portion that shows up from E[z], second piece is the part
+    # that shows up regardless as in Wang and Blei (2013) for example.  Last element is just siginv
+    hess <- -((diag(phisums) - crossprod(EB)) - 
+                Ndoc*(diag(theta) - theta%o%theta))[1:length(eta),1:length(eta)] + siginv
+    
+    ###
+    # Bound
+    
+    nu <- try(chol2inv(chol.default(hess)), silent=TRUE)
+    if(class(nu)=="try-error") {
+      #brute force solve
+      nu <- solve(hess)
+      #only if we would produce negative variances do we bother doing nearPD
+      if(any(diag(nu)<0)) nu <- as.matrix(nearPD(nu)$mat)
+    }
+#    diff <- eta - mu.i
+    logphinorm <- log(colSums(theta*beta.i))
+    part1 <- sum(doc.ct*logphinorm)
+    bound <- part1 + .5*determinant(nu, logarithm=TRUE)$modulus -
+      .5*sum(diff*crossprod(diff,siginv)) - sigmaentropy
+    bound <- as.numeric(bound)
+    
+    # done inferring the document
     
     # update sufficient statistics 
-    sigma.ss <- sigma.ss + doc.results$eta$nu
-    beta.ss[[aspect]][,words] <- doc.results$phis + beta.ss[[aspect]][,words]
-    bound[i] <- doc.results$bound
-    lambda[[i]] <- doc.results$eta$lambda
+    sigma.ss <- sigma.ss + nu
+    beta.ss[[aspect]][,words] <- phi + beta.ss[[aspect]][,words]
+    bound[i] <- bound
+    lambda[[i]] <- eta
     if(verbose && i%%ctevery==0) cat(".")
   }
   if(verbose) cat("\n") #add a line break for the next message.

--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -65,9 +65,11 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
     betaexpeta_colsums <- 0
     betaexpeta <- 0
     sumexpeta <- 0
+    global_eta <- 0
     eta <- optim(par=init, 
                        fn=function(eta) {
                          # {\sum_{v=1}^V c_v log [\sum_k beta_{k,v} exp(eta_k)] }- Wlog \sum exp(eta_k)
+                         global_eta <<- eta
                          expeta <<- c(exp(eta),1)
                          sumexpeta <<- sum(expeta)
                          betaexpeta <<- beta.i * expeta
@@ -81,57 +83,67 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
                          part2 <- .5*sum(diff*siginvdiff)
                          part2 - part1  
                        },  gr=function(eta) {
-                         denom <- doc.ct/betaexpeta_colsums
-                         part1 <- (betaexpeta%*%denom)[-length(expeta)] - expeta[1]*(Ndoc/sumexpeta)  
-                         as.numeric(siginvdiff - part1)
+                         if (identical(eta,global_eta)) {
+                           denom <- doc.ct/betaexpeta_colsums
+                           part1 <- (betaexpeta%*%denom)[-length(expeta)] - expeta[1]*(Ndoc/sumexpeta)  
+                           as.numeric(siginvdiff - part1)
+                         } else {
+                           expeta.sh <- exp(eta) 
+                           expeta <- c(expeta.sh,1)
+                           Ez <- expeta*beta
+                           denom <- doc.ct/.colSums(Ez, nrow(Ez), ncol(Ez))
+                           part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
+                           part2 <- siginv%*%(eta-mu) 
+                           as.numeric(part2 - part1)                           
+                         }
                        },
                        method="BFGS", 
                        control=list(maxit=500)
     )$par
     
-    doc.results <- logisticnormal(eta=init, mu=mu.i, siginv=siginv, beta=beta.i, 
-                                 doc=doc, sigmaentropy=sigmaentropy)
+#     doc.results <- logisticnormal(eta=init, mu=mu.i, siginv=siginv, beta=beta.i, 
+#                                  doc=doc, sigmaentropy=sigmaentropy)
     
-#     #Solve for Hessian/Phi/Bound returning the result
-#       theta <- expeta/sumexpeta
-#   
-#    #pieces for the derivatives of the exp(eta)beta part
-#        EB <- t(betaexpeta)/betaexpeta_colsums #transpose and norm by (now) the row
-#   
-#    #at this point EB is the phi matrix
-#       phi <- EB*(doc.ct) #multiply through by word count
-#       phisums <- colSums(phi)
-#       phi <- t(phi) #transpose so its in the K by W format expected
-#       EB <- EB*sqrt(doc.ct) #set up matrix to take the cross product
-#     
-#     #First piece is the quotient rule portion that shows up from E[z], second piece is the part
-#     # that shows up regardless as in Wang and Blei (2013) for example.  Last element is just siginv
-#      hess <- -((diag(phisums) - crossprod(EB)) - 
-#                  Ndoc*(diag(theta) - theta%o%theta))[1:length(eta),1:length(eta)] + siginv
-#     
-#     ###
-#     # Bound
-#     
-#     nu <- try(chol2inv(chol.default(hess)), silent=TRUE)
-#     if(class(nu)=="try-error") {
-#       #brute force solve
-#       nu <- solve(hess)
-#       #only if we would produce negative variances do we bother doing nearPD
-#       if(any(diag(nu)<0)) nu <- as.matrix(nearPD(nu)$mat)
-#     }
-#      logphinorm <- log(colSums(theta*beta.i))
-#      part1 <- sum(doc.ct*logphinorm)
-# 
-#     bound[i] <- as.numeric(part1 + .5*determinant(nu, logarithm=TRUE)$modulus -
-#       .5*sum(diff*crossprod(diff,siginv)) - sigmaentropy)
-#     
-#     # done inferring the document
+    #Solve for Hessian/Phi/Bound returning the result
+      theta <- expeta/sumexpeta
+  
+   #pieces for the derivatives of the exp(eta)beta part
+       EB <- t(betaexpeta)/betaexpeta_colsums #transpose and norm by (now) the row
+  
+   #at this point EB is the phi matrix
+      phi <- EB*(doc.ct) #multiply through by word count
+      phisums <- colSums(phi)
+      phi <- t(phi) #transpose so its in the K by W format expected
+      EB <- EB*sqrt(doc.ct) #set up matrix to take the cross product
+    
+    #First piece is the quotient rule portion that shows up from E[z], second piece is the part
+    # that shows up regardless as in Wang and Blei (2013) for example.  Last element is just siginv
+     hess <- -((diag(phisums) - crossprod(EB)) - 
+                 Ndoc*(diag(theta) - theta%o%theta))[1:length(eta),1:length(eta)] + siginv
+    
+    ###
+    # Bound
+    
+    nu <- try(chol2inv(chol.default(hess)), silent=TRUE)
+    if(class(nu)=="try-error") {
+      #brute force solve
+      nu <- solve(hess)
+      #only if we would produce negative variances do we bother doing nearPD
+      if(any(diag(nu)<0)) nu <- as.matrix(nearPD(nu)$mat)
+    }
+     logphinorm <- log(colSums(theta*beta.i))
+     part1 <- sum(doc.ct*logphinorm)
+
+    bound[i] <- as.numeric(part1 + .5*determinant(nu, logarithm=TRUE)$modulus -
+      .5*sum(diff*crossprod(diff,siginv)) - sigmaentropy)
+    
+    # done inferring the document
 
     # update sufficient statistics 
-    sigma.ss <- sigma.ss + doc.results$eta$nu
-    beta.ss[[aspect]][,words] <- doc.results$phis + beta.ss[[aspect]][,words]
-    bound[i] <- doc.results$bound
-    lambda[[i]] <- doc.results$eta$lambda
+    sigma.ss <- sigma.ss + nu
+    beta.ss[[aspect]][,words] <- phi + beta.ss[[aspect]][,words]
+#     bound[i] <- doc.results$bound
+    lambda[[i]] <- eta
 
     if(verbose && i%%ctevery==0) cat(".")
   }

--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -43,7 +43,7 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
   # For right now we are just doing everything in serial.
   # the challenge with multicore is efficient scheduling while
   # maintaining a small dimension for the sufficient statistics.
-  print("Using the new code 2")
+  print("Using the new code 3 - LBFGS")
   for(i in 1:N) {
     #update components
     doc <- documents[[i]]
@@ -97,7 +97,7 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
 #                            as.numeric(part2 - part1)                           
 #                          }
                        },
-                       method="BFGS", 
+                       method="L-BFGS", 
                        control=list(maxit=500)
     )$par
     

--- a/R/STMestep.R
+++ b/R/STMestep.R
@@ -43,7 +43,7 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
   # For right now we are just doing everything in serial.
   # the challenge with multicore is efficient scheduling while
   # maintaining a small dimension for the sufficient statistics.
-  print("Using the new code 3 - LBFGS")
+  cat("Using the new code 5 - checking cache")
   for(i in 1:N) {
     #update components
     doc <- documents[[i]]
@@ -65,11 +65,11 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
     betaexpeta_colsums <- 0
     betaexpeta <- 0
     sumexpeta <- 0
-#    global_eta <- 0
+    global_eta <- 0
     eta <- optim(par=init, 
                        fn=function(eta) {
                          # {\sum_{v=1}^V c_v log [\sum_k beta_{k,v} exp(eta_k)] }- Wlog \sum exp(eta_k)
-#                         global_eta <<- eta
+                         global_eta <<- eta
                          expeta <<- c(exp(eta),1)
                          sumexpeta <<- sum(expeta)
                          betaexpeta <<- beta.i * expeta
@@ -83,21 +83,21 @@ estep <- function(documents, beta.index, update.mu, #null allows for intercept o
                          part2 <- .5*sum(diff*siginvdiff)
                          part2 - part1  
                        },  gr=function(eta) {
-#                         if (identical(eta,global_eta)) {
+                         if (identical(eta,global_eta)) {
                            denom <- doc.ct/betaexpeta_colsums
                            part1 <- (betaexpeta%*%denom)[-length(expeta)] - expeta[1]*(Ndoc/sumexpeta)  
                            as.numeric(siginvdiff - part1)
-#                          } else {
-#                            expeta.sh <- exp(eta) 
-#                            expeta <- c(expeta.sh,1)
-#                            Ez <- expeta*beta
-#                            denom <- doc.ct/.colSums(Ez, nrow(Ez), ncol(Ez))
-#                            part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
-#                            part2 <- siginv%*%(eta-mu) 
-#                            as.numeric(part2 - part1)                           
-#                          }
+                          } else {
+                            expeta.sh <- exp(eta) 
+                           expeta <- c(expeta.sh,1)
+                           Ez <- expeta*beta
+                           denom <- doc.ct/.colSums(Ez, nrow(Ez), ncol(Ez))
+                           part1 <- (Ez%*%denom)[-length(expeta)] - expeta.sh*(Ndoc/sum(expeta))  
+                           part2 <- siginv%*%(eta-mu) 
+                           as.numeric(part2 - part1)                           
+                         }
                        },
-                       method="L-BFGS", 
+                       method="BFGS", 
                        control=list(maxit=500)
     )$par
     

--- a/R/STMln.R
+++ b/R/STMln.R
@@ -10,6 +10,7 @@ logisticnormal <- function(eta, mu, siginv, beta, doc, sigmaentropy) {
   doc.ct <- doc[2,]
   Ndoc <- sum(doc.ct)
   #even at K=100, BFGS is faster than L-BFGS
+  # what we're trying to do here is find the value of eta that minimizes the lhood function.  
   optim.out <- optim(par=eta, fn=lhood, gr=grad,
                      method="BFGS", control=list(maxit=500),
                      doc.ct=doc.ct, mu=mu,
@@ -70,6 +71,7 @@ grad <- function(eta, doc.ct, mu, siginv, beta, Ndoc=sum(doc.ct)) {
 #       nearly as often.  Particularly I suspect some of the elements in the
 #       cross product could be sped up quite a bit.
 #   NB: Bound and hessian barely communicate with one another here.
+
 hpb <- function(eta, doc.ct, mu, siginv, beta, Ndoc=sum(doc.ct), sigmaentropy) {
   #basic transforms
   expeta <- c(exp(eta),1)
@@ -101,6 +103,7 @@ hpb <- function(eta, doc.ct, mu, siginv, beta, Ndoc=sum(doc.ct), sigmaentropy) {
     if(any(diag(nu)<0)) nu <- as.matrix(nearPD(nu)$mat)
   }
   diff <- eta - mu
+  if (circuit == 10) print(str(diff))
   logphinorm <- log(colSums(theta*beta))
   part1 <- sum(doc.ct*logphinorm)
   bound <- part1 + .5*determinant(nu, logarithm=TRUE)$modulus -

--- a/R/prepDocuments.R
+++ b/R/prepDocuments.R
@@ -36,7 +36,10 @@ prepDocuments <- function(documents, vocab, meta=NULL,
   } 
    
   triplet <- doc.to.ijv(documents) #this also fixes the zero indexing.
+  
+  nms <- names(documents) 
   documents <- ijv.to.doc(triplet$i, triplet$j, triplet$v)
+  names(documents) <- nms
   docs.removed <- c()
   
   #Detect Missing Terms
@@ -52,7 +55,9 @@ prepDocuments <- function(documents, vocab, meta=NULL,
     vocab <- vocab[vocablist]
     new.map <- cbind(vocablist, 1:length(vocablist))
     documents <- lapply(documents, function(d) {
+      nm <- names(d)
       d[1,] <- new.map[match(d[1,], new.map[,1]),2]
+      names(d) <- nm
       return(d)
     })
     wordcounts <- wordcounts[vocablist]

--- a/R/readCorpus.R
+++ b/R/readCorpus.R
@@ -41,8 +41,16 @@ read.dtm <- function(dtm) {
 read.slam <- function(corpus) {
   #convert a simple triplet matrix to list format.
   if(!inherits(corpus, "simple_triplet_matrix")) stop("corpus is not a simple triplet matrix")
-  documents <- ijv.to.doc(corpus$i, corpus$j, corpus$v)
-  vocab <- corpus$dimnames[[2]]
+  if ("TermDocumentMatrix" %in% class(corpus)) {
+    non_empty_docs <- which(slam::col_sums(corpus) != 0)
+    documents <- ijv.to.doc(corpus[,non_empty_docs]$j, corpus[,non_empty_docs]$j, corpus[,non_empty_docs]$v) 
+    names(documents) <- corpus[,non_empty_docs]$dimnames$Docs
+  } else {
+    non_empty_docs <- which(slam::row_sums(corpus) != 0)
+    documents <- ijv.to.doc(corpus[non_empty_docs,]$i, corpus[non_empty_docs,]$j, corpus[non_empty_docs,]$v) 
+    names(documents) <- corpus[non_empty_docs,]$dimnames$Docs
+  }
+  vocab <- corpus$dimnames$Terms
   return(list(documents=documents,vocab=vocab))
 }
 

--- a/R/readCorpus.R
+++ b/R/readCorpus.R
@@ -43,7 +43,7 @@ read.slam <- function(corpus) {
   if(!inherits(corpus, "simple_triplet_matrix")) stop("corpus is not a simple triplet matrix")
   if ("TermDocumentMatrix" %in% class(corpus)) {
     non_empty_docs <- which(slam::col_sums(corpus) != 0)
-    documents <- ijv.to.doc(corpus[,non_empty_docs]$j, corpus[,non_empty_docs]$j, corpus[,non_empty_docs]$v) 
+    documents <- ijv.to.doc(corpus[,non_empty_docs]$j, corpus[,non_empty_docs]$i, corpus[,non_empty_docs]$v) 
     names(documents) <- corpus[,non_empty_docs]$dimnames$Docs
   } else {
     non_empty_docs <- which(slam::row_sums(corpus) != 0)

--- a/R/stm.R
+++ b/R/stm.R
@@ -47,7 +47,7 @@ stm <- function(documents, vocab, K,
   #Check the Number of Topics
   if(missing(K)) stop("K, the number of topics, is required.")
   if(!(posint(K) && length(K)==1 && K>1)) stop("K must be a positive integer greater than 1.")
-  if(K==2) warning("K=2 is equivalent to a unidimensional scaling model which you may prefer.")
+  if(K==2) warning("K=2 is equivalent to a unidimensional scaling model, which you may prefer.")
   
   #Iterations, Verbose etc.
   if(!(length(max.em.its)==1 & posint(max.em.its))) stop("Max EM iterations must be a single positive integer")

--- a/R/stm.R
+++ b/R/stm.R
@@ -12,7 +12,11 @@ stm <- function(documents, vocab, K,
                 kappa.prior=c("L1", "Jeffreys"), control=list())  {
   
   #Match Arguments and save the call
-  init.type <- match.arg(init.type)
+  #Default to Spectral initialization if vocabulary is smaller than 5000 terms
+  if (missing(init.type)) {
+    if (length(vocab) < 5000) {init.type <- "Spectral"}
+    else {init.type <- match.arg(init.type)}
+  }
   Call <- match.call()
   
   #Documents

--- a/R/stm.R
+++ b/R/stm.R
@@ -73,6 +73,7 @@ stm <- function(documents, vocab, K,
     if(!is.matrix(prevalence) & !inherits(prevalence, "formula")) stop("Prevalence Covariates must be specified as a model matrix or as a formula")
     xmat <- makeTopMatrix(prevalence,data)
     if(nrow(na.omit(xmat)) != length(documents)) stop("Complete cases in prevalence covariate does not match the number of documents.")
+    rownames(xmat) <- names(documents)
   } else {
     xmat <- NULL
   }
@@ -99,6 +100,7 @@ stm <- function(documents, vocab, K,
     betaindex <- rep(1, length(documents))
   }
   A <- length(unique(betaindex)) #define the number of aspects
+  names(betaindex) <- names(documents)
   
   #Checks for Dimension agreement
   ny <- length(betaindex)

--- a/R/stm.control.R
+++ b/R/stm.control.R
@@ -167,15 +167,15 @@ stm.control <- function(documents, vocab, settings, model) {
   }
   beta$beta <- NULL
   lambda <- cbind(lambda,0)
-  colnames(mu$mu) <- names(documents)
-  names(beta$kappa$m) <- vocab
+  if (! is.null(mu$mu)) colnames(mu$mu) <- names(documents)
+  if (! is.null(beta$kappa$m)) names(beta$kappa$m) <- vocab
   for (i in 1:length(beta$logbeta)) {
     colnames(beta$logbeta[[i]]) <- vocab
   }
   eta <- lambda[,-ncol(lambda), drop=FALSE]
-  rownames(eta) <- names(documents)
+  if (! is.null(eta)) rownames(eta) <- names(documents)
   theta <- exp(lambda - row.lse(lambda))
-  rownames(theta) <- names(documents)
+  if (! is.null(theta)) rownames(theta) <- names(documents)
   model <- list(mu=mu, sigma=sigma, beta=beta, settings=settings,
                 vocab=vocab, convergence=convergence, 
                 theta=theta, 

--- a/R/stm.control.R
+++ b/R/stm.control.R
@@ -24,6 +24,29 @@ stm.control <- function(documents, vocab, settings, model) {
     #discard the old object
     rm(model)
   } else {
+    # need to test if documents and vocab are the same
+    if (verbose) cat("Checking if documents or vocabular have changed...\n")
+    if (! identical(colnames(mu$mu), names(documents))) {
+      cat("Documents not identical")
+      docsToDrop <- which(! colnames(mu$mu) %in% names(documents) )
+      # should first handle the case where documents are out of order...  Actually might be best if we did this at the beginning of the if clause
+      if (length(docsToDrop) != 0) {
+        # There were documents before that are no longer being considered.  Need to remove the appropriate components of the data structures
+      }
+      docsToAdd <- which()
+    } else {
+      cat("Documents identical")
+    }
+    if (! identical(colnames(mu$mu), names(documents))) {
+      cat("Documents not identical")
+    } else {
+      cat("Documents identical")
+    } 
+    if (! identical(vocab, model$vocab)) {
+      cat("Vocabulary not identical")
+    } else {
+      cat("Vocabulary identical")
+    }
     if(verbose) cat("Restarting Model...\n")
     #extract from a standard STM object so we can simply continue.
     mu <- model$mu

--- a/R/stm.control.R
+++ b/R/stm.control.R
@@ -172,7 +172,6 @@ stm.control <- function(documents, vocab, settings, model) {
   for (i in 1:length(beta$logbeta)) {
     colnames(beta$logbeta[[i]]) <- vocab
   }
-#  for (i in 1:length(settings$wcounts)) names(settings$dim$wcounts[[i]]) <- vocab
   eta <- lambda[,-ncol(lambda), drop=FALSE]
   rownames(eta) <- names(documents)
   theta <- exp(lambda - row.lse(lambda))

--- a/R/stm.control.R
+++ b/R/stm.control.R
@@ -167,10 +167,20 @@ stm.control <- function(documents, vocab, settings, model) {
   }
   beta$beta <- NULL
   lambda <- cbind(lambda,0)
+  colnames(mu$mu) <- names(documents)
+  names(beta$kappa$m) <- vocab
+  for (i in 1:length(beta$logbeta)) {
+    colnames(beta$logbeta[[i]]) <- vocab
+  }
+  for (i in 1:length(settings$wcounts)) names(settings$dim$wcounts[[i]]) <- vocab
+  eta <- lambda[,-ncol(lambda), drop=FALSE]
+  rownames(eta) <- names(documents)
+  theta <- exp(lambda - row.lse(lambda))
+  rownames(theta) <- names(documents)
   model <- list(mu=mu, sigma=sigma, beta=beta, settings=settings,
                 vocab=vocab, convergence=convergence, 
-                theta=exp(lambda - row.lse(lambda)), 
-                eta=lambda[,-ncol(lambda), drop=FALSE],
+                theta=theta, 
+                eta=eta,
                 invsigma=solve(sigma), time=time)
   class(model) <- "STM"  
   return(model)

--- a/R/stm.control.R
+++ b/R/stm.control.R
@@ -172,7 +172,7 @@ stm.control <- function(documents, vocab, settings, model) {
   for (i in 1:length(beta$logbeta)) {
     colnames(beta$logbeta[[i]]) <- vocab
   }
-  for (i in 1:length(settings$wcounts)) names(settings$dim$wcounts[[i]]) <- vocab
+#  for (i in 1:length(settings$wcounts)) names(settings$dim$wcounts[[i]]) <- vocab
   eta <- lambda[,-ncol(lambda), drop=FALSE]
   rownames(eta) <- names(documents)
   theta <- exp(lambda - row.lse(lambda))

--- a/man/stm.Rd
+++ b/man/stm.Rd
@@ -39,7 +39,7 @@ stm(documents, vocab, K,
   \item{data}{
 an optional data frame containing the prevalence and/or content covariates.  If unspecified the variables are taken from the active environment.}
   \item{init.type}{
-The method of initialization.  Must be either Latent Dirichlet Allocation ("LDA"), "Random" or "Spectral".  See details for more info. If you want to replicate a previous result, see the argument \code{seed}.  
+The method of initialization.  Must be either Latent Dirichlet Allocation ("LDA"), "Random" or "Spectral".  Defaults to "Spectral" if \cote{vocab} has fewer than 5000 terms, otherwise defaults to \code{LDA}.  See details for more info. If you want to replicate a previous result, see the argument \code{seed}.  
 }
   \item{seed}{
 Seed for the random number generator. \code{stm} saves the seed it uses on every run so that any result can be exactly reproduced.  When attempting to reproduce a result with that seed, it should be specified here.


### PR DESCRIPTION
I'm trying to make a few modifications to make stm more robust for use with the tm:: package, and hopefully parallelize it a bit.  This is a first step with three modifications:  
1.  read.slam handles document term matrices as well as term document matrices; this saves the memory overhead of converting; 
2.   Empty documents are detected in read.slam; and
3.  Document names are preserved through read.slam and prepDocuments.  Why does this matter?  First of all because read.slam and prepDocuments can drop documents, and this can cause documents and meta to get out-of sync.  Similarly, if stm is part of a larger workflow, then the output may have to be recombined, and the document names provide a means for doing that.  In addition, if stm is ultimately going to be able to fold-in additional documents and terms, then we have to keep track.  

I'm now working to make sure the document names get preserved through the stm function and to see if there are ways to parallelize it.  Notably, stm will use multiple cores out-of-box because a lot of the work gets done in BLAS, and a multi-threaded BLAS is easily selected in R.
