### PR TITLE
modified it to work with content covariates

### DIFF
--- a/R/plot.searchK.R
+++ b/R/plot.searchK.R
@@ -9,9 +9,10 @@ plot.searchK<-function(x, ...){
   plot(g$K,g$residual,type="p", main="Residuals", xlab="Number of Topics (K)", ylab="Residuals")
   lines(g$K,g$residual,lty=1,col=1 )
   
-  
-  plot(g$K,g$semcoh,type="p", main="Semantic Coherence", xlab="Number of Topics (K)", ylab="Semantic Coherence")
-  lines(g$K,g$semcoh,lty=1,col=1 ) 
+  if(!is.null(g$semcoh)){
+    plot(g$K,g$semcoh,type="p", main="Semantic Coherence", xlab="Number of Topics (K)", ylab="Semantic Coherence")
+    lines(g$K,g$semcoh,lty=1,col=1 ) 
+  }
   
   #plot(g$K,g$exclus,type="n", main="Exclusivity", xlab="Number of Topics (K)", ylab="Exclusivity")
   #lines(g$K,g$exclus,lty=1,col=1 )  

--- a/R/searchK.R
+++ b/R/searchK.R
@@ -17,8 +17,10 @@ searchK <- function(documents, vocab, K, init.type = "Spectral",
     model <- stm(documents=heldout$documents,vocab=heldout$vocab,
                  K=K[i], init.type=init.type,...)
     #calculate values to return
-    g$exclus[i]<-mean(unlist(exclusivity(model, M=M, frexw=.7)))
-    g$semcoh[i]<-mean(unlist(semanticCoherence(model, heldout$documents, M)))
+    if( !"content" %in% names(list(...)) ) {  # only calculate exclusivity for models without content covariates
+      g$exclus[i]<-mean(unlist(exclusivity(model, M=M, frexw=.7)))
+      g$semcoh[i]<-mean(unlist(semanticCoherence(model, heldout$documents, M)))
+    }
     g$heldout[i]<-eval.heldout(model, heldout$missing)$expected.heldout    
     g$residual[i]<-checkResiduals(model,heldout$documents)$dispersion
     g$bound[i]<-max(model$convergence$bound)
@@ -26,6 +28,11 @@ searchK <- function(documents, vocab, K, init.type = "Spectral",
     g$em.its[i]<-length(model$convergence$bound)    
   }
   g <- as.data.frame(g)
+  if( "content" %in% names(list(...)) ) {
+    warning("Exclusivity calculation only designed for models without content covariates", call.=FALSE)
+    g$exclus <- NULL
+    g$semcoh <- NULL
+  }
   toreturn <- list(results=g, call=match.call(expand.dots=TRUE))
   class(toreturn)<- "searchK"
   return(toreturn)


### PR DESCRIPTION
I ran into issues using searchK() because my model involves content covariates. I saw that it would be a quick fix to modify searchK() and plot.searchK() to just skip the semantic coherence and exclusivity calculations and plot, so they would work with models that have content covariates. 