### PR TITLE
Keep meta as a 2-d object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Maintainer: Brandon Stewart <bms4@princeton.edu>
 Depends: R (>= 2.10)
 LinkingTo: Rcpp, RcppArmadillo
 Imports: matrixStats, splines, slam, lda, stringr, Matrix, glmnet, Rcpp (>= 0.11.3), grDevices, graphics, stats, utils
-Suggests: igraph, SnowballC, tm (>= 0.6), huge, clue, wordcloud, KernSmooth, NLP, LDAvis, geometry, Rtsne
+Suggests: igraph, SnowballC, tm (>= 0.6), huge, clue, wordcloud, KernSmooth, NLP, LDAvis, geometry, Rtsne,
+    testthat
 LazyData: yes
 Description: The Structural Topic Model (STM) allows researchers 
   to estimate topic models with document-level covariates. 

--- a/R/prepDocuments.R
+++ b/R/prepDocuments.R
@@ -25,7 +25,7 @@ prepDocuments <- function(documents, vocab, meta=NULL,
   if(!is.null(subsample)) {
     index <- sample(1:length(documents), subsample)
     documents <- documents[index]
-    if(!is.null(meta)) meta <- meta[index,] 
+    if(!is.null(meta)) meta <- meta[index, , drop = FALSE] 
   }
   
   #check that there are no 0 length documents
@@ -89,7 +89,7 @@ prepDocuments <- function(documents, vocab, meta=NULL,
   }
   
   if(!is.null(docs.removed) & !is.null(meta)){
-    meta<-meta[-docs.removed,]
+    meta<-meta[-docs.removed, , drop = FALSE]
   }
   #recast everything as an integer
   documents <- lapply(documents, function(x) matrix(as.integer(x), nrow=2))

--- a/R/textProcessor.R
+++ b/R/textProcessor.R
@@ -101,7 +101,7 @@ textProcessor <- function(documents, metadata=NULL,
   #If there is metadata we need to remove some documents
   if(!is.null(metadata)) {
     docindex <- unique(dtm$i)
-    metadata <- NLP::meta(txt)[docindex,]
+    metadata <- NLP::meta(txt)[docindex, , drop = FALSE]
   }
   out <- read.slam(dtm) #using the read.slam() function in stm to convert
   

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(stm)
+
+test_check("stm")

--- a/tests/testthat/prepare.R
+++ b/tests/testthat/prepare.R
@@ -1,0 +1,14 @@
+context("Prepare text")
+
+test_that("textProcessor and prepDocuments correctly subset metadata ", {
+  data("gadarian")
+  
+  txtOut <- textProcessor(documents = gadarian$open.ended.response, 
+                          metadata = data.frame(MetaID = gadarian$MetaID),
+                          sparselevel = .8)
+  expect_equal(nrow(txtOut$meta), length(txtOut$documents))
+  
+  prepped <- prepDocuments(txtOut$documents, txtOut$vocab, 
+                           txtOut$meta, upper.thresh = 100)
+  expect_equal(nrow(prepped$meta), length(prepped$documents))
+})

--- a/tests/testthat/test-prepare.R
+++ b/tests/testthat/test-prepare.R
@@ -2,13 +2,13 @@ context("Prepare text")
 
 test_that("textProcessor and prepDocuments correctly subset metadata ", {
   data("gadarian")
-  
-  txtOut <- textProcessor(documents = gadarian$open.ended.response, 
+
+  txtOut <- textProcessor(documents = gadarian$open.ended.response,
                           metadata = data.frame(MetaID = gadarian$MetaID),
                           sparselevel = .8)
   expect_equal(nrow(txtOut$meta), length(txtOut$documents))
-  
-  prepped <- prepDocuments(txtOut$documents, txtOut$vocab, 
+
+  prepped <- prepDocuments(txtOut$documents, txtOut$vocab,
                            txtOut$meta, upper.thresh = 100)
   expect_equal(nrow(prepped$meta), length(prepped$documents))
 })


### PR DESCRIPTION
Hi, 

It looks like the `meta` object that is used to hold metadata in the `textProcessor` and `prepDocuments` functions can float between being either a data frame/matrix or a vector. This causes problems when  `prepDocuments` tries to index `meta` to stay in line with the document list. For example, the call to `prepDocuments` here:

```r
data("gadarian")
txtOut <- textProcessor(documents = gadarian$open.ended.response, 
                        metadata = data.frame(MetaID = gadarian$MetaID))
prepped <- prepDocuments(txtOut$documents, txtOut$vocab, 
                         txtOut$meta, upper.thresh = 100)
```

...will throw the error "Error in meta[-docs.removed, ] : incorrect number of dimensions," as `meta` had previously been simplified to a vector. I've changed the functions to preserve `meta`'s 2-d data structure.

Are you amenable to including tests in stm? If so, I will issue another PR with the test I wrote.

Thanks for a great package,
Chris