### PR TITLE
Update thetaPosterior.R

### DIFF
--- a/R/thetaPosterior.R
+++ b/R/thetaPosterior.R
@@ -72,18 +72,23 @@ thetapost.local <- function(model, documents, nsims) {
     hess <- ln.hess(eta, theta, doc.beta, doc.ct, siginv)    
     nu <- try(chol2inv(chol.default(hess)),silent=TRUE)
     if(class(nu)=="try-error") {
+    
       # if it failed we try tightening by taking a BFGS step
-      optim.out <- optim(par=eta, fn=lhoodcpp, gr=gradcpp,
-                         method="BFGS", control=list(maxit=500),
-                         doc.ct=doc.ct, mu=mu[,i],
-                         siginv=siginv, beta=doc.beta, Ndoc=sum(doc.ct))
+      if (NCOL(mu) == 1) mu.i <- mu else mu.i <- mu[,i]
+      optim.out <- optim(par = eta, fn = lhoodcpp, gr = gradcpp, 
+                         method = "BFGS", control = list(maxit = 500), 
+                         doc_ct = doc.ct, mu = mu.i, siginv = siginv, 
+                         beta = doc.beta)
+                         
       eta <- optim.out$par
       theta <- softmax(c(eta,0))
       hess <- ln.hess(eta, theta, doc.beta, doc.ct, siginv) 
       nu <- try(chol2inv(chol.default(hess)),silent=TRUE)
       if(class(nu)=="try-error") {
+      
         #oh man, it failed again?  Well now we try some really expensive newton optimization
-        newton.out <- newton(eta, doc.ct, mu[,i], siginv, doc.beta, hess, max.its=1000)
+        newton.out <- newton(eta, doc.ct, mu.i, siginv, doc.beta, hess, max.its=1000)
+        
         #if the newton even failed it forces an answer using nearPD so we do have a solution here.
         nu <- newton.out$nu
         eta <- newton.out$eta
@@ -111,17 +116,17 @@ newton <- function(eta, doc.ct, mu, siginv, beta,
   }
   while(its < max.its) {
     #compute the search direction
-    dir <- -solve(hess)%*%gradcpp(eta, doc.ct, mu, siginv, beta)
+    dir <- -solve(hess)%*%gradcpp(eta, beta, doc.ct, mu, siginv)
     #line search
     maxint <- 2
     opt <- optimize(f=search, interval=c(-2,maxint), dir=dir, 
-                    eta=eta,doc.ct=doc.ct, mu=mu,
+                    eta=eta,doc_ct=doc.ct, mu=mu,
                     siginv=siginv, beta=beta, maximum=FALSE)
-    while(opt$objective > lhoodcpp(eta, doc.ct, mu, siginv, beta)) {
+    while(opt$objective > lhoodcpp(eta, beta, doc.ct, mu, siginv)) {
       #re-assess at a smaller point
       maxint <- min(maxint/2, opt$minimum - .00001*opt$minimum)
       opt <- optimize(f=search, interval=c(0,maxint), dir=dir, 
-                      eta=eta,doc.ct=doc.ct, mu=mu,
+                      eta=eta,doc_ct=doc.ct, mu=mu,
                       siginv=siginv, beta=beta, maximum=FALSE)
     }
     


### PR DESCRIPTION
Note that I'm unsure about (3).

(1) For lhoodcpp, it's lhoodcpp(SEXP eta, SEXP beta,
SEXP doc_ct, SEXP mu, SEXP siginv), so nothing for Ndoc. If you dig further in the function, it actually calculates this:

double ndoc = sum(doc_cts);

(2) Also, doc.ct should be doc_ct.

(3) Mu[,i] returns an error if there was no prevalence information in the model -- i.e., mu is a column vector. I'm assuming for models with no metadata, the same mu vector should be passed every iteration of i. I guess it just needs an if statement then? My quick fix works, but I'm unsure if it accomplishes what you wanted, and I haven't gone through the optimization routine to verify.

(4) For newton gradcpp(eta, doc.ct, mu, siginv, beta), beta is in the wrong place.

(5) For newton lhoodcpp(eta, doc.ct, mu, siginv, beta), beta is in the wrong place like above.

(6) Newton also has doc.ct where it should be doc_ct.
