### PR TITLE
add reorder.topics from LDAvis::createJSON 

### DIFF
--- a/R/toLDAvis.R
+++ b/R/toLDAvis.R
@@ -29,6 +29,8 @@
 #' @param as.gist Passed to \code{\link[LDAvis]{serVis}} "should the vis be
 #' uploaded as a gist? Will prompt for an interactive login if the GITHUB_PAT
 #' environment variable is not set"
+#' @param reorder.topics Passed to \code{\link[LDAvis]{createJSON}} "Should LDAvis
+#' re-order the K topics in order of decreasing proportion? Default is True"
 #' @references Carson Sievert and Kenny Shirley. LDAvis: Interactive
 #' Visualization of Topic Models. R package version 0.3.1.
 #' https://github.com/cpsievert/LDAvis
@@ -46,7 +48,7 @@
 #' }
 #' @export
 toLDAvis<-function(mod,docs,R=30,plot.opts=list(xlab ="PC1", ylab = "PC2"),
-                    lambda.step=.1,out.dir=tempfile(),open.browser=interactive(),as.gist=FALSE){
+                    lambda.step=.1,out.dir=tempfile(),open.browser=interactive(),as.gist=FALSE,reorder.topics=TRUE){
 if(!requireNamespace("LDAvis",quietly=TRUE)) stop("Please install LDAvis package to use this function. You will also need servr.")
 theta<-mod$theta
 if(length(mod$beta$logbeta)>1) stop("This function does not yet allow content covariates.")
@@ -58,6 +60,6 @@ phi <- exp(mod$beta$logbeta[[1]])
 vocab <- mod$vocab
 doc.length <- as.integer(unlist(lapply(docs, function(x) sum(x[2,]))))
 term.frequency <- mod$settings$dim$wcounts$x
-f<-LDAvis::createJSON(phi=phi,theta=theta,doc.length=doc.length,vocab=vocab,term.frequency=term.frequency,lambda.step = lambda.step)
+f<-LDAvis::createJSON(phi=phi,theta=theta,doc.length=doc.length,vocab=vocab,term.frequency=term.frequency,lambda.step=lambda.step,reorder.topics=reorder.topics)
 LDAvis::serVis(f,out.dir=out.dir,open.browser=open.browser,as.gist=as.gist,R = R)
 }


### PR DESCRIPTION
set to true by default, so does not change the default behavior of toLDAvis
found this feature of LDAvis to be useful when manually labeling topics