### PR TITLE
Fix noise addition for tSNE

### DIFF
--- a/R/spectral.R
+++ b/R/spectral.R
@@ -300,12 +300,13 @@ tsneAnchor <- function(Qbar, verbose=TRUE, init.dims=50, perplexity=30) {
       
       dup <- which(dup)
       for(r in dup) {
-        row <- Qbar[Xpca,]
+        row <- Qbar[r,]
         row[row!=0] <- runif(sum(row!=0),0,1e-5) # add a bit of noise to non-zero duplicates
         row <- row/sum(row) #renormalize
-        Xpca[r,] <- row
+        Qbar[r,] <- row
       }
       #and now do it again
+      Xpca <- rsvd::rpca(Qbar, min(init.dims,ncol(Qbar)), center=TRUE, scale=FALSE, retx=TRUE)$x[,1: min(50,ncol(Qbar))]
       proj <- Rtsne::Rtsne(Xpca, pca=FALSE, dims=3,
                            initial_dims=init.dims,
                            perplexity=perplexity)

--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ install_github("bstewart/stm",dependencies=TRUE)
 
 Note that this will install all the packages suggested and required to run our package.  It may take a few minutes the first time, but this only needs to be done on the first use.  In the future you can update to the most recent development version using the same code. 
 
-You can also grab the binaries or source files for the latest release here: (https://github.com/bstewart/stm/releases).  Then use `install.packages` with `repos=NULL` so that
-```
-install.packages(filepath, repos = NULL)
-```    
-
 ### Getting Started
 See the vignette for several example analyses.  The main function to estimate the model is `stm()` but there are a host of other useful functions.  If you have your documents already converted to term-document matrices you can ingest them using `readCorpus()`.  If you just have raw texts you will want to start with `textProcessor()`.
 


### PR DESCRIPTION
As far as I can tell, the function below is supposed to do this:

1. find rows with identical loadings
2. add noise to the corresponding rows of `Qbar`
3. renormalize the perturbed rows
4. try PCA and tSNE again

I fixed the matrix comprehension with this assumption. I suppose you could also perturb the loadings, but the renormalization step wouldn't make much sense in that case.