### PR TITLE
Development

### DIFF
--- a/stm.Rproj
+++ b/stm.Rproj
@@ -14,6 +14,6 @@ LaTeX: pdfLaTeX
 
 BuildType: Package
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageBuildArgs: --resave-data     --no-build-vignettes
+PackageBuildArgs: --resave-data    --compact-vignettes=gs+qpdf
 PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/test-stm-options.R
+++ b/tests/testthat/test-stm-options.R
@@ -31,8 +31,8 @@ test_that("Test that ngroups works", {
   expect_identical(class(test), "STM")
 })
 
-test_that("Test that multi-core searchK works", {
-  test <- searchK(poliblog5k.docs, poliblog5k.voc, K=c(3,4), 
-                     init.type="Random", max.em.its=1, cores = 2)
-  expect_identical(class(test), "searchK")
-})
+#test_that("Test that multi-core searchK works", {
+#  test <- searchK(poliblog5k.docs, poliblog5k.voc, K=c(3,4), 
+#                     init.type="Random", max.em.its=1, cores = 2)
+#  expect_identical(class(test), "searchK")
+#})


### PR DESCRIPTION
This doesn’t work on Windows and returns a message to that effect.  We
can’t have it as a test because it then fails when it runs on CRAN.