### PR TITLE
Use topic number instead of index number (fixes #148)

### DIFF
--- a/R/estimateEffect.R
+++ b/R/estimateEffect.R
@@ -298,7 +298,8 @@ summary.estimateEffect <- function(object, topics=NULL, nsim=500, ...) {
   }
   tables <- vector(mode="list", length=length(topics))
   for(i in seq_along(topics)) {
-    sims <- lapply(object$parameters[[i]], function(x) rmvnorm(nsim, x$est, x$vcov))
+    topic = topics[i]
+    sims <- lapply(object$parameters[[topic]], function(x) rmvnorm(nsim, x$est, x$vcov))
     sims <- do.call(rbind,sims)
     est<- colMeans(sims)
     se <- sqrt(apply(sims,2, stats::var))


### PR DESCRIPTION
See #148, seq_along gives the index number in the topics parameter, so need to use topics[i] rather than i as the topic number. Let me know if you need me to modify the PR in any way! 