### PR TITLE
explicitly set tolower in dtm

### DIFF
--- a/R/textProcessor.R
+++ b/R/textProcessor.R
@@ -188,7 +188,7 @@ textProcessor <- function(documents, metadata=NULL,
   
   #Make a matrix
   if(verbose) cat("Creating Output... \n")
-  dtm <- tm::DocumentTermMatrix(txt, control=list(wordLengths=wordLengths))
+  dtm <- tm::DocumentTermMatrix(txt, control=list(wordLengths=wordLengths, tolower = FALSE))
   if(sparselevel!=1) {
     ntokens <- sum(dtm$v)
     V <- ncol(dtm)


### PR DESCRIPTION
https://github.com/bstewart/stm/blob/410508f410a3bd53677dbe756f5afe8b424f13eb/R/textProcessor.R#L191

Here's the mapping. Presumably all of [defaults](https://www.rdocumentation.org/packages/tm/versions/0.7-4/topics/termFreq) here need to be FALSE, thus respecting the fact that you may have already done some of these steps or not. The `tolower` option however defaults to TRUE so to respect user choices it needs to be coded to false here.
```R
 dtm <- tm::DocumentTermMatrix(txt, control=list(
wordLengths=wordLengths
,tolower=lowercase
,language=language
,removePunctuation=removepunctuation
,removeNumbers=removenumbers
,stopwords=removestopwords
,stemming=stem
)) 
```