### PR TITLE
Add check for "logical" data in outputdata().  Logical is handled identically to character data.

### DIFF
--- a/R/produce_cmatrix.R
+++ b/R/produce_cmatrix.R
@@ -2,7 +2,7 @@
 #type: class of variable
 #data: data in which the variable exists
 outputdata <- function(type, data){
-  if(type=="character"){
+  if(type=="character"|type=="logical"){
     tab <- table(data[[names(type)]])
     mode <- names(tab)[which.max(tab)]
     return(factor(mode, levels=levels(as.factor(data[[names(type)]]))))


### PR DESCRIPTION
Connected to issue#186
[https://github.com/bstewart/stm/issues/186](https://github.com/bstewart/stm/issues/186)

I tested this using the following code.  Happy to include the following as a unit test if desired:

data1 <- c(T, T, T, F)
data2 <- c('a', 'a', 'b', 'a')
data_list <- data.frame(data1, data2)
types <- lapply(data_list, class)
types <- unlist(types)
outputdata(types[1], data_list)
outputdata(types[2], data_list)