### PR TITLE
typo in help textProcessor

### DIFF
--- a/R/textProcessor.R
+++ b/R/textProcessor.R
@@ -97,7 +97,7 @@
 #' assumes that you have passed a regular expression and passes that directly
 #' along to \code{gsub}.
 #' @param v1 A logical which defaults to \code{FALSE}.  If set to \code{TRUE} it
-#' will use the ordering of operations we use used in Version 1.0 of the package.
+#' will use the ordering of operations we used in Version 1.0 of the package.
 #' @return \item{documents}{A list containing the documents in the stm format.}
 #' \item{vocab }{Character vector of vocabulary.} \item{meta}{Data frame or
 #' matrix containing the user-supplied metadata for the retained documents.}


### PR DESCRIPTION
fixed a typo in the doc of ```textProcessor()```