### PR TITLE
Added 'Top-R Most Salient Terms' functionality to toLDAvis

### DIFF
--- a/R/toLDAvis.R
+++ b/R/toLDAvis.R
@@ -108,5 +108,5 @@ if(any(phi==0)){
 vocab <- mod$vocab
 doc.length <- as.integer(unlist(lapply(docs, function(x) sum(x[2,]))))
 term.frequency <- mod$settings$dim$wcounts$x
-LDAvis::createJSON(plot.opts = plot.opts,phi=phi,theta=theta,doc.length=doc.length,vocab=vocab,term.frequency=term.frequency,lambda.step=lambda.step,reorder.topics=reorder.topics)
+LDAvis::createJSON(plot.opts = plot.opts,phi=phi,theta=theta,doc.length=doc.length,vocab=vocab,term.frequency=term.frequency,lambda.step=lambda.step,reorder.topics=reorder.topics,R=R)
 }


### PR DESCRIPTION
The functions toLDAvis and toLDAvisJson has the argument R=30, however, it wasn't used when calling createJSON, making LDAvis use the default value instead of user specified value. 