### PR TITLE
Switch to arma_cerr_stream<T>

### DIFF
--- a/src/STMCfuns.cpp
+++ b/src/STMCfuns.cpp
@@ -146,7 +146,7 @@ SEXP hpbcpp(SEXP eta,
    //It basically keeps arma from printing errors from chol to the console.
    std::ostream nullstream(0);
    //arma::set_stream_err2(nullstream);
-   arma::set_cerr_stream(nullstream);
+   arma::arma_cerr_stream<char>(&nullstream);
    
    ////
    //Invert via cholesky decomposition


### PR DESCRIPTION
Armadillo updates its coding convention over time. We have been fairly hard at work to have RcppArmadillo-using packages switch from a now-deprecated older way of instantiatig variables to a newer one (see [issue #391](https://github.com/RcppCore/RcppArmadillo/issues/391) for details; this PR is part of the related [issue #402](https://github.com/RcppCore/RcppArmadillo/issues/402)).

When compiling packages using RcppArmadillo with the deprecation-warning-suppressor we still use, some new warnings come up. One concerns a deprecated way of setting an output or error stream as your package does in one spot in one file. Changing this is fairly straightforward, and affects only that one file.

The package compiles with the change as it did before, and test fine as well.

It would be much appreciated if you could apply this pull request and update the package at CRAN within the next few months. Let me know if you have any questions.